### PR TITLE
API-808: Fix URL Encoding Issue in API Reference Docs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,11 +237,12 @@ HTTPSnippet.prototype.prepare = function (request, encodeUri = false) {
   request.fullUrl = url.format(request.uriObj)
 
   if (!encodeUri) {
-    request.fullUrl = decodeURI(request.fullUrl)
+    request.fullUrl = decodeURIComponent(request.fullUrl)
     request.url = decodeURI(request.url)
-    request.uriObj.path = decodeURI(request.uriObj.path)
+    request.uriObj.path = decodeURIComponent(request.uriObj.path)
     request.uriObj.pathname = decodeURI(request.uriObj.pathname)
     request.uriObj.href = decodeURI(request.uriObj.href)
+    request.uriObj.search = decodeURIComponent(request.uriObj.search)
   }
 
   return request

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ var validate = require('har-validator/lib/async')
 const { formDataIterator, isBlob } = require('./helpers/form-data.js')
 
 // constructor
-var HTTPSnippet = function (data, encodeUri = true) {
+var HTTPSnippet = function (data, encodeUri = false) {
   var entries
   var self = this
   var input = Object.assign({}, data)

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,6 @@ HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
   // construct a full url
   request.fullUrl = url.format(request.uriObj)
 
-
   if (!encodeUri) {
     request.fullUrl = decodeURI(request.fullUrl)
     request.url = decodeURI(request.url)

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ var HTTPSnippet = function (data, encodeUri = false) {
   })
 }
 
-HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
+HTTPSnippet.prototype.prepare = function (request, encodeUri = false) {
   // construct utility properties
   request.queryObj = {}
   request.headersObj = {}

--- a/test/index.js
+++ b/test/index.js
@@ -6,25 +6,27 @@ var fixtures = require('./fixtures')
 var HTTPSnippet = require('../src')
 
 var should = require('should')
+var url = require('url')
 
 describe('HTTPSnippet', function () {
   it('should not have URI encoding ON by default', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.full).requests[0]
-    req.fullUrl.should.eql(decodeURI(req.fullUrl))
+    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    req.fullUrl.should.eql(decodeURIComponent(req.fullUrl))
     req.url.should.equal(decodeURI(req.url))
-    req.uriObj.path.should.equal(decodeURI(req.uriObj.path))
+    req.uriObj.path.should.equal(decodeURIComponent(req.uriObj.path))
     req.uriObj.pathname.should.equal(decodeURI(req.uriObj.pathname))
     req.uriObj.href.should.equal(decodeURI(req.uriObj.href))
+    req.uriObj.search.should.equal(decodeURIComponent(req.uriObj.search))
     done()
   })
 
   it('should have URI encoding ON when the flag is set', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.full, true).requests[0]
-    req.fullUrl.should.eql(encodeURI(req.fullUrl))
+    var req = new HTTPSnippet(fixtures.requests.query, true).requests[0]
     req.url.should.equal(encodeURI(req.url))
-    req.uriObj.path.should.equal(encodeURI(req.uriObj.path))
     req.uriObj.pathname.should.equal(encodeURI(req.uriObj.pathname))
     req.uriObj.href.should.equal(encodeURI(req.uriObj.href))
+    req.uriObj.path.should.equal(encodeURI(req.uriObj.pathname) + '?' + req.uriObj.search)
+    req.fullUrl.should.equal(url.format(req.uriObj))
     done()
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,26 @@ var HTTPSnippet = require('../src')
 var should = require('should')
 
 describe('HTTPSnippet', function () {
+  it('should not have URI encoding ON by default', function (done) {
+    var req = new HTTPSnippet(fixtures.requests.full).requests[0]
+    req.fullUrl.should.eql(decodeURI(req.fullUrl))
+    req.url.should.equal(decodeURI(req.url))
+    req.uriObj.path.should.equal(decodeURI(req.uriObj.path))
+    req.uriObj.pathname.should.equal(decodeURI(req.uriObj.pathname))
+    req.uriObj.href.should.equal(decodeURI(req.uriObj.href))
+    done()
+  })
+
+  it('should have URI encoding ON when the flag is set', function (done) {
+    var req = new HTTPSnippet(fixtures.requests.full, true).requests[0]
+    req.fullUrl.should.eql(encodeURI(req.fullUrl))
+    req.url.should.equal(encodeURI(req.url))
+    req.uriObj.path.should.equal(encodeURI(req.uriObj.path))
+    req.uriObj.pathname.should.equal(encodeURI(req.uriObj.pathname))
+    req.uriObj.href.should.equal(encodeURI(req.uriObj.href))
+    done()
+  })
+
   it('should return false if no matching target', function (done) {
     var snippet = new HTTPSnippet(fixtures.requests.short)
 


### PR DESCRIPTION
### What?

- The API Team uses this fork of httpSnippet for docs generation and by default we are disabling URI encoding in the snippets generated so as to not render encoded URIs on the docs.
- Now, by default the query/search parameters are also not encoded.
- Eg. ../request/%7Bid%7D?q=xyz%2Cpqr&key=value --> ../request/{id}?q=xyz,pqr&key=value.
- Since this fork is only used by the API team it is not a breaking change.

### Test
Wrote unit tests to validate the changes.